### PR TITLE
add kwargs to get_flask_blueprint function

### DIFF
--- a/metador_core/widget/server/__init__.py
+++ b/metador_core/widget/server/__init__.py
@@ -168,13 +168,13 @@ class WidgetServer:
             f"{self._bokeh_endpoint}/{known[name]}", arguments=req_args
         )
 
-    def get_flask_blueprint(self, *args):
+    def get_flask_blueprint(self, *args, **kwargs):
         """Return the internal widget API Flask blueprint.
 
         Widgets require a flask app with this API mounted to work.
         """
         assert self._bokeh_endpoint
-        api = Blueprint(*args)
+        api = Blueprint(*args, **kwargs)
 
         @api.route("/")
         def index():


### PR DESCRIPTION
I want to pass url_prefix at the Blueprint initialization. Had to change get_flask_blueprint for that.